### PR TITLE
Improve authentication setup with higherOrders

### DIFF
--- a/src/helpers/clearAccessToken.js
+++ b/src/helpers/clearAccessToken.js
@@ -2,15 +2,15 @@
 import { serialize as serializeCookie } from 'cookie'
 import { AUTH_COOKIE } from '@constants/cookies'
 
-const clearAccessToken = (context: any): void => {
+const clearAccessToken = (context: any = {}): void => {
   const epochTimestamp = new Date(0)
   const cookies = serializeCookie(AUTH_COOKIE, '', {
     // Setting a `maxAge` in the past expires the cookie.
     maxAge: epochTimestamp
   })
+  const response = context.res
 
-  if (context && context.ctx.res) {
-    const response = context.ctx.res
+  if (response) {
     response.setHeader('Set-Cookie', cookies)
   } else {
     document.cookie = cookies

--- a/src/helpers/getAccessToken.js
+++ b/src/helpers/getAccessToken.js
@@ -2,11 +2,8 @@
 import { parse as parseCookie } from 'cookie'
 import { AUTH_COOKIE } from '@constants/cookies'
 
-const getAccessToken = (context?: any): string => {
-  const cookies =
-    context && context.ctx.req
-      ? context.ctx.req.headers.cookie
-      : document.cookie
+const getAccessToken = (context: any = {}): string => {
+  const cookies = context.req ? context.req.headers.cookie : document.cookie
 
   return parseCookie(cookies || '')[AUTH_COOKIE]
 }

--- a/src/helpers/redirectTo.js
+++ b/src/helpers/redirectTo.js
@@ -1,10 +1,10 @@
 // @flow
 import Router from 'next/router'
 
-const redirectTo = (context: any, target: string): void => {
-  if (context && context.ctx.res) {
-    const response = context.ctx.res
+const redirectTo = (context: any = {}, target: string): void => {
+  const response = context.res
 
+  if (response) {
     response.writeHead(303, { Location: target })
     response.end()
   } else {

--- a/src/higherOrders/withApolloClient/index.js
+++ b/src/higherOrders/withApolloClient/index.js
@@ -12,7 +12,7 @@ type Props = {
 
 const withApolloClient = (App: any) => {
   class ApolloClient extends React.Component<Props> {
-    static async getInitialProps(context: any) {
+    static async getInitialProps(context: any = {}) {
       const { Component, router } = context
       const appProps = App.getInitialProps
         ? await App.getInitialProps(context)

--- a/src/higherOrders/withApolloClient/initApollo.js
+++ b/src/higherOrders/withApolloClient/initApollo.js
@@ -3,7 +3,6 @@
 import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost'
 import fetch from 'isomorphic-unfetch'
 import getAccessToken from '@helpers/getAccessToken'
-import clearAccessToken from '@helpers/clearAccessToken'
 import redirectTo from '@helpers/redirectTo'
 
 let apolloClient = null
@@ -20,8 +19,7 @@ const customFetch = (context: any = {}) => async (
   // We intercept the response and log the user out if their access token is not
   // valid.
   if (response.status === 401) {
-    clearAccessToken(context)
-    redirectTo(context, '/login')
+    redirectTo(context, '/logout')
   }
 
   return response

--- a/src/higherOrders/withApolloClient/initApollo.js
+++ b/src/higherOrders/withApolloClient/initApollo.js
@@ -8,7 +8,10 @@ import redirectTo from '@helpers/redirectTo'
 
 let apolloClient = null
 
-const customFetch = (context: any) => async (URI: string, options: any) => {
+const customFetch = (context: any = {}) => async (
+  URI: string,
+  options: any
+) => {
   const token = getAccessToken(context)
   options.headers.Authorization = token ? `bearer ${token}` : ''
 
@@ -24,7 +27,7 @@ const customFetch = (context: any) => async (URI: string, options: any) => {
   return response
 }
 
-const create = (context: any, initialState: any) =>
+const create = (context: any = {}, initialState: any) =>
   new ApolloClient({
     connectToDevTools: process.browser,
     ssrMode: !process.browser,

--- a/src/higherOrders/withAuthentication/index.js
+++ b/src/higherOrders/withAuthentication/index.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react'
+import getAccessToken from '@helpers/getAccessToken'
+import redirectTo from '@helpers/redirectTo'
+
+type Props = {}
+
+const withAuthentication = (Component: any) => {
+  class NoAuthentication extends React.Component<Props> {
+    static async getInitialProps(context: any = {}) {
+      const accessToken = getAccessToken(context)
+
+      if (!accessToken) {
+        redirectTo(context, '/login')
+      }
+
+      return {}
+    }
+
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+
+  return NoAuthentication
+}
+
+export default withAuthentication

--- a/src/higherOrders/withNoAuthentication/index.js
+++ b/src/higherOrders/withNoAuthentication/index.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react'
+import getAccessToken from '@helpers/getAccessToken'
+import redirectTo from '@helpers/redirectTo'
+
+type Props = {}
+
+const withNoAuthentication = (Component: any) => {
+  class NoAuthentication extends React.Component<Props> {
+    static async getInitialProps(context: any = {}) {
+      const accessToken = getAccessToken(context)
+
+      if (accessToken) {
+        redirectTo(context, '/')
+      }
+
+      return {}
+    }
+
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+
+  return NoAuthentication
+}
+
+export default withNoAuthentication

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -5,40 +5,13 @@ import { PageTransition } from 'next-page-transitions'
 import { ApolloProvider } from 'react-apollo'
 import { ThemeProvider } from 'styled-components'
 import { ToastContainer } from 'react-toastify'
-import getAccessToken from '@helpers/getAccessToken'
-import clearAccessToken from '@helpers/clearAccessToken'
-import redirectTo from '@helpers/redirectTo'
 import withApolloClient from '@higherOrders/withApolloClient'
 import 'react-toastify/dist/ReactToastify.css'
 import theme from '../styles/theme'
 import '../styles/reset.css'
 import '../styles/style.css'
 
-const UNAUTHENTICATED_PATHS = ['/register', '/login']
-
-class MyApp extends App {
-  static async getInitialProps(context) {
-    const accessToken = getAccessToken(context)
-    const path = context.ctx.pathname
-    const isUnauthenticatedPath = UNAUTHENTICATED_PATHS.includes(path)
-
-    // Logout route actually doesn’t exist but allows us to log the user out.
-    if (path === '/logout') {
-      clearAccessToken(context)
-      redirectTo(context, '/login')
-
-      return {}
-    }
-
-    if (accessToken && isUnauthenticatedPath) {
-      redirectTo(context, '/')
-    } else if (!accessToken && !isUnauthenticatedPath) {
-      redirectTo(context, '/login')
-    }
-
-    return {}
-  }
-
+class ZolaApp extends App {
   render() {
     const { Component, router, pageProps, apolloClient } = this.props
 
@@ -69,4 +42,4 @@ class MyApp extends App {
   }
 }
 
-export default withApolloClient(MyApp)
+export default withApolloClient(ZolaApp)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,8 @@
 // @flow
 import React from 'react'
 import HelloWorld from '@components/HelloWorld'
+import withAuthentication from '@higherOrders/withAuthentication'
 
-export default () => <HelloWorld />
+const Index = () => <HelloWorld />
+
+export default withAuthentication(Index)

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,12 +1,15 @@
 // @flow
 import React from 'react'
+import withNoAuthentication from '@higherOrders/withNoAuthentication'
 import Wrapper from '@components/Wrapper'
 import LoginHeader from '@components/LoginHeader'
 import LoginForm from '@containers/LoginForm'
 
-export default () => (
+const Login = () => (
   <Wrapper center width="small">
     <LoginHeader />
     <LoginForm />
   </Wrapper>
 )
+
+export default withNoAuthentication(Login)

--- a/src/pages/logout.js
+++ b/src/pages/logout.js
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react'
+import clearAccessToken from '@helpers/clearAccessToken'
+import redirectTo from '@helpers/redirectTo'
+
+type Props = {}
+
+class Logout extends React.Component<Props> {
+  static async getInitialProps(context: any = {}) {
+    clearAccessToken(context)
+    redirectTo(context, '/login')
+
+    return {}
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default Logout

--- a/src/pages/project.js
+++ b/src/pages/project.js
@@ -4,8 +4,9 @@ import Wrapper from '@components/Wrapper'
 import Sidebar from '@components/Sidebar'
 import ProjectSidebar from '@components/ProjectSidebar'
 import KeysList from '@components/KeysList'
+import withAuthentication from '@higherOrders/withAuthentication'
 
-export default () => (
+const Project = () => (
   <Wrapper flex>
     <Sidebar />
     <ProjectSidebar />
@@ -14,3 +15,5 @@ export default () => (
     </Wrapper>
   </Wrapper>
 )
+
+export default withAuthentication(Project)

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -1,12 +1,15 @@
 // @flow
 import React from 'react'
+import withNoAuthentication from '@higherOrders/withNoAuthentication'
 import Wrapper from '@components/Wrapper'
 import RegistrationHeader from '@components/RegistrationHeader'
 import RegistrationForm from '@containers/RegistrationForm'
 
-export default () => (
+const Register = () => (
   <Wrapper center width="small">
     <RegistrationHeader />
     <RegistrationForm />
   </Wrapper>
 )
+
+export default withNoAuthentication(Register)


### PR DESCRIPTION
I had multiple issues with the current setup:
- 404 pages didn’t work (they showed an “unexpected error” page instead).
- Putting all of our auth logic in `_app.js`’s `getInitialProps` looks like a bad idea.
- After trying to use `getInitialProps` in `logout.js` I realized the `_app.js`’s context shape was different… 

After those changes, I think it looks cleaner and:
- Accessing `/foo` correctly renders a 404.
- Accessing `/login` or `/register` while being logged in redirects to `/`.
- Accessing `/` (authenticated route) when not logged in redirects to `/login`.
- Receiving a 401 when making a request to the API automatically logs the user out.